### PR TITLE
refactor: clean up action.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 permissions:
   contents: read
 
-on: pull_request
+on:
+  pull_request:
 
 jobs:
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ commits that should have been auto-squashed.
   uses: matijs/no-fixups-action@v1
 ```
 
-This action will only run on pull requests and will fail when used on, for
-example, pushes. There is one input. There are no outputs.
+**Note**: This action will only run on `pull request` events and will fail when
+used on, for example, `push` or `schedule`. There is one input. There are no
+outputs.
 
 It is not necessary to use
 [actions/checkout](https://github.com/actions/checkout) first. This action takes

--- a/action.yml
+++ b/action.yml
@@ -10,34 +10,26 @@ inputs:
       Set `fetch-depth` and `ref` yourself. See below for values.
     default: 'false'
 
+defaults:
+  run:
+    shell: bash
+
 runs:
   using: composite
   steps:
     - name: Check if this is a pull request
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        echo '### Error' >> ${GITHUB_STEP_SUMMARY}
-        echo '' >> ${GITHUB_STEP_SUMMARY}
-        echo 'This action can only be run on pull requests.' >> ${GITHUB_STEP_SUMMARY}
+        echo "::error::This action can only be run on pull_request events"
         exit 1
-      shell: bash
-
     - name: Checkout
       if: ${{ inputs.skip-checkout == 'false' }}
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: Set GitHub Action path
-      env:
-        ACTION_PATH: ${{ github.action_path }}
-      run: echo "${ACTION_PATH}" >> ${GITHUB_PATH}
-      shell: bash
-
     - name: Check if there are 'amend!', 'fixup!', and 'squash!' commits
-      run: action.sh
-      shell: bash
+      run: ${{ github.action_path }}/action.sh
 
 branding:
   icon: git-commit


### PR DESCRIPTION
- Remove the action path step because it could just be inline using `github.action_path`
- Put `shell` before `run` because it reads nices
- Set an error message using `::error::{message}` instead of using a job summary because it should suffice