### PR TITLE
chore: dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
       day: "saturday"
       time: "00:00"
       timezone: "Etc/UTC"
+    cooldowns:
+      default-days: 5
 


### PR DESCRIPTION
Add cooldowns for Dependabot. Only update GitHub Actions that have been available for at least 5 days.